### PR TITLE
Add ability to send mail through SMTP

### DIFF
--- a/config/config.default.lisp
+++ b/config/config.default.lisp
@@ -48,10 +48,13 @@
 (defvar *email-from* "noreply@yourdomain.com"
   "The email address all turtl emails come from.")
 
+(defvar *smtp-host* nil
+  "If you want to send mail with SMTP rather than sendgrid.com, set to a valid
+   SMTP server (can be localhost)")
 (defvar *email-user* ""
-  "The username used for sending email. Needs to be set on load.")
+  "The sendgrid username used for sending email. Needs to be set on load.")
 (defvar *email-pass* ""
-  "The password used for sending email. Needs to be set on load.")
+  "The sendgrid password used for sending email. Needs to be set on load.")
 
 (defvar *display-errors* t
   "Whether or not to show errors in HTTP responses. Useful for debugging, bad

--- a/turtl.asd
+++ b/turtl.asd
@@ -21,6 +21,7 @@
                #:bordeaux-threads
                #:trivial-backtrace
                #:xmls
+               #:cl-smtp
                #:vom)
   :components
   ((:file "package")


### PR DESCRIPTION
The only way to send mail was using sendgrid.com, which wasn't said in
the template config file and prevent people that don't want to pay for
mails to send mails.

This commit add an option to use a SMTP server. No SSL or authentication
options, but anyone is free to contribute :-)

The communication with the SMTP server is done with the help of cl-smtp,
licensed under the terms of the LLGPL (http://opensource.franz.com/preamble.html),
which seems to be compatible with Turtl licensing:
"The license allows developers and companies to use and integrate
software released under the LGPL into their own (even proprietary)
software"
(https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License)
